### PR TITLE
feat(repl): improve multi-line input handling for strings and brackets

### DIFF
--- a/eta/repl/history.rkt
+++ b/eta/repl/history.rkt
@@ -1,0 +1,108 @@
+#lang racket
+
+(provide repl-history-store
+         repl-history-create
+         repl-history-add
+         repl-history-get
+         get-source-from-identifier
+         clear-history
+         show-history)
+
+(require "../utils/console.rkt")
+
+;; Vector-based history store for REPL
+(struct repl-history-store (vector index count) #:transparent)
+
+;  repl-history-create
+;     Create a new REPL history store
+;  Arguments:
+;     [capacity] - Maximum capacity of the history (default: 100)
+;  Returns:
+;     A new REPL history store
+(define (repl-history-create [capacity 100])
+  (repl-history-store (make-vector capacity #f) 0 0))
+
+;  repl-history-add
+;     Add an input to the REPL history
+;  Arguments:
+;     history - REPL history store
+;     input - Input string
+;  Returns:
+;     A pair of updated REPL history store and history index (1-based)
+(define (repl-history-add history input)
+  (let* ([vector (repl-history-store-vector history)]
+         [index (repl-history-store-index history)]
+         [count (repl-history-store-count history)]
+         [capacity (vector-length vector)])
+    (vector-set! vector index input)
+    (let ([new-index (modulo (add1 index) capacity)]
+          [new-count (add1 count)])
+      (values (repl-history-store vector new-index new-count) new-count))))
+
+;  repl-history-get
+;     Get an input from the REPL history
+;  Arguments:
+;     history - REPL history store
+;     index - History index (1-based)
+;  Returns:
+;     Input string or #f
+(define (repl-history-get history index)
+  (let* ([vector (repl-history-store-vector history)]
+         [count (repl-history-store-count history)]
+         [capacity (vector-length vector)])
+    (if (and (>= index 1) (<= index count))
+        (let* ([real-idx (modulo (- (+ count index) 1) capacity)])
+          (vector-ref vector real-idx))
+        #f)))
+
+;  get-source-from-identifier
+;     Get source code from a file identifier
+;  Arguments:
+;     history - REPL history store
+;     file-id - File identifier (string, symbol, or list)
+;  Returns:
+;     Source code (string) or #f
+(define (get-source-from-identifier history file-id)
+  (cond
+    ;; Regular file
+    [(and (string? file-id) (file-exists? file-id))
+     (with-handlers ([exn:fail? (lambda (e) #f)])
+       (file->string file-id))]
+    ;; REPL history
+    [(and (list? file-id) 
+          (= (length file-id) 2)
+          (eq? (first file-id) 'repl-history)
+          (number? (second file-id)))
+     (repl-history-get history (second file-id))]
+    [else #f]))
+
+;  clear-history
+;     Clear REPL history and return a new empty history store
+;  Arguments:
+;     history - Current REPL history store
+;  Returns:
+;     A new empty REPL history store
+(define (clear-history history)
+  (displayln (colorize "History cleared." 'green))
+  (repl-history-create (vector-length (repl-history-store-vector history))))
+
+;  show-history
+;     Display REPL command history
+;  Arguments:
+;     history - REPL history store
+;  Returns:
+;     void (prints to stdout)
+(define (show-history history)
+  (let ([count (repl-history-store-count history)])
+    (if (= count 0)
+        (displayln (colorize "History is empty." 'yellow))
+        (let loop ([i 1])
+          (when (<= i count)
+            (let ([entry (repl-history-get history i)])
+              (when entry
+                (displayln (format "~a: ~a" 
+                                  (colorize (number->string i) 'cyan)
+                                  (if (> (string-length entry) 60)
+                                      (string-append (substring entry 0 57) "...")
+                                      entry))))
+              (loop (add1 i))))))))

--- a/eta/repl/input-reader.rkt
+++ b/eta/repl/input-reader.rkt
@@ -1,0 +1,150 @@
+#lang racket
+
+(provide StringState
+         ParseState
+         string-state
+         count-bracket-balance
+         input-needs-continuation?
+         read-multi-line-input)
+
+(require "../utils/console.rkt")
+
+;; String analysis state
+(struct StringState (in-string? escaped?) #:transparent)
+
+;; Parser state including bracket balance and string state
+(struct ParseState (balance string-state) #:transparent)
+
+;  string-state
+;     Analyze the string literal state in a given string
+;  Arguments:
+;     str - Input string to analyze
+;     [initial-state] - Initial string analysis state (default: not in string, not escaped)
+;  Returns:
+;     A StringState struct
+(define (string-state str [initial-state (StringState #f #f)])
+  (define (process-chars chars state)
+    (if (null? chars)
+        state  ; Return final state
+        (let* ([char (car chars)]
+               [rest (cdr chars)]
+               [in-string? (StringState-in-string? state)]
+               [escaped? (StringState-escaped? state)])
+          (cond
+            ;; Handle escape sequences inside strings
+            [(and in-string? escaped?)
+             (process-chars rest (StringState in-string? #f))]
+            
+            ;; Handle escape character
+            [(and in-string? (char=? char #\\))
+             (process-chars rest (StringState in-string? #t))]
+            
+            ;; Handle string delimiters
+            [(char=? char #\")
+             (process-chars rest (StringState (not in-string?) #f))]
+            
+            ;; Skip other characters
+            [else
+             (process-chars rest (StringState in-string? #f))]))))
+  
+  (process-chars (string->list str) initial-state))
+
+;  count-bracket-balance
+;     Count the bracket balance (left - right) in a string
+;     Ignoring brackets inside string literals
+;  Arguments:
+;     str - Input string to analyze
+;     [initial-state] - Initial parse state (default: balance 0, not in string, not escaped)
+;  Returns:
+;     A ParseState struct
+(define (count-bracket-balance str [initial-state (ParseState 0 (StringState #f #f))])
+  (define (process-chars chars state)
+    (if (null? chars)
+        state  ; Return final state
+        (let* ([char (car chars)]
+               [rest (cdr chars)]
+               [balance (ParseState-balance state)]
+               [str-state (ParseState-string-state state)]
+               [in-string? (StringState-in-string? str-state)]
+               [escaped? (StringState-escaped? str-state)])
+          (cond
+            ;; Handle escape sequences inside strings
+            [(and in-string? escaped?)
+             (process-chars rest 
+                           (ParseState balance 
+                                        (StringState in-string? #f)))]
+            
+            ;; Handle escape character
+            [(and in-string? (char=? char #\\))
+             (process-chars rest 
+                           (ParseState balance 
+                                        (StringState in-string? #t)))]
+            
+            ;; Handle string delimiters
+            [(char=? char #\")
+             (process-chars rest 
+                           (ParseState balance 
+                                        (StringState (not in-string?) #f)))]
+            
+            ;; Count opening brackets (when not in string)
+            [(and (not in-string?) (or (char=? char #\() (char=? char #\[) (char=? char #\{)))
+             (process-chars rest 
+                           (ParseState (+ balance 1) 
+                                        (StringState in-string? #f)))]
+            
+            ;; Count closing brackets (when not in string)
+            [(and (not in-string?) (or (char=? char #\)) (char=? char #\]) (char=? char #\})))
+             (process-chars rest 
+                           (ParseState (- balance 1) 
+                                        (StringState in-string? #f)))]
+            
+            ;; Skip other characters
+            [else
+             (process-chars rest 
+                           (ParseState balance 
+                                        (StringState in-string? #f)))]))))
+  
+  (process-chars (string->list str) initial-state))
+
+;  input-needs-continuation?
+;     Determine whether input needs to continue to the next line
+;  Arguments:
+;     input - Current input string
+;     [initial-state] - Initial parse state (default: balance 0, not in string, not escaped)
+;  Returns:
+;     Boolean indicating whether more input is needed
+(define (input-needs-continuation? input [initial-state (ParseState 0 (StringState #f #f))])
+  (let* ([final-state (count-bracket-balance input initial-state)]
+         [balance (ParseState-balance final-state)]
+         [str-state (ParseState-string-state final-state)]
+         [in-string? (StringState-in-string? str-state)])
+    (or (> balance 0)     ; Unclosed brackets
+        in-string?        ; Unclosed string
+        )))
+
+;  read-multi-line-input
+;     Read input until bracket balance is zero or negative and all string literals are closed
+;  Arguments:
+;     initial-line - First line of input
+;     [prompt-fn] - Optional function to display continuation prompt (default: no prompt)
+;  Returns:
+;     Complete multi-line input as a single string
+(define (read-multi-line-input initial-line [prompt-fn (lambda () (void))])
+  (let loop ([lines (list initial-line)]
+             [parse-st (ParseState 0 (StringState #f #f))])
+    (let* ([line-state (count-bracket-balance (car lines) parse-st)]
+           [new-balance (ParseState-balance line-state)]
+           [new-str-state (ParseState-string-state line-state)]
+           [new-in-string? (StringState-in-string? new-str-state)])
+      (if (and (<= new-balance 0) (not new-in-string?))
+          ;; If balance is zero/negative and not in a string, we're done
+          (string-join (reverse lines) "\n")
+          (begin
+            (prompt-fn)
+            (let ([next-line (read-line)])
+              (cond
+                [(eof-object? next-line)
+                 (string-join (reverse lines) "\n")]
+                [else
+                 ;; Continue with next line
+                 (loop (cons next-line lines) line-state)])))))))


### PR DESCRIPTION
fix #44 

- Refactor input parser to use proper struct-based design
- Fix string literal parsing to correctly handle unclosed strings
- Ignore brackets inside string literals when determining continuation
- Improve REPL history commands
- Follow functional programming style with small, focused functions